### PR TITLE
Add zip.sats/zip.dats with pure ATS2 ZIP parsing (no C %{ blocks)

### DIFF
--- a/zip.dats
+++ b/zip.dats
@@ -1,0 +1,68 @@
+(* zip.dats -- ZIP local file header parsing in pure ATS2 *)
+
+(* NO C %{ blocks. All C interop uses = "mac#" externs declared in zip.sats.
+   This follows the conversion pattern from old_quire_claude.md:
+   Step 1: C primitives as extern (buf_get_u8, buf_get_u16le, buf_get_u32le)
+   Step 2: No global state in %{ blocks
+   Step 3: ATS implementations using the primitives *)
+
+#include "share/atspre_staload.hats"
+staload "./better_rust.sats"
+staload "./zip.sats"
+
+(* ============================================================
+   Signature check: 0x04034b50 = {0x50, 0x4b, 0x03, 0x04}
+   ============================================================ *)
+
+implement zip_check_signature{l}{n}(pf, p) = let
+  val b0 = buf_get_u8(pf, p, 0)
+  val b1 = buf_get_u8(pf, p, 1)
+  val b2 = buf_get_u8(pf, p, 2)
+  val b3 = buf_get_u8(pf, p, 3)
+in
+  if b0 = 0x50 then
+    if b1 = 0x4b then
+      if b2 = 0x03 then
+        if b3 = 0x04 then ZIP_SIG_YES()
+        else ZIP_SIG_NO()
+      else ZIP_SIG_NO()
+    else ZIP_SIG_NO()
+  else ZIP_SIG_NO()
+end
+
+(* ============================================================
+   Parse the fixed 30-byte header
+   ============================================================ *)
+
+implement zip_parse_local_header{l}{n}(pf, p) = let
+  val version   = buf_get_u16le(pf, p, 4)
+  val flags     = buf_get_u16le(pf, p, 6)
+  val compress  = buf_get_u16le(pf, p, 8)
+  val mod_time  = buf_get_u16le(pf, p, 10)
+  val mod_date  = buf_get_u16le(pf, p, 12)
+  val crc       = buf_get_u32le(pf, p, 14)
+  val comp_sz   = buf_get_u32le(pf, p, 18)
+  val uncomp_sz = buf_get_u32le(pf, p, 22)
+  val fname_len = buf_get_u16le(pf, p, 26)
+  val extra_len = buf_get_u16le(pf, p, 28)
+in
+  @{
+    version_needed= version,
+    flags= flags,
+    compression= compress,
+    mod_time= mod_time,
+    mod_date= mod_date,
+    crc32= crc,
+    compressed_size= comp_sz,
+    uncompressed_size= uncomp_sz,
+    filename_len= fname_len,
+    extra_len= extra_len
+  }
+end
+
+(* ============================================================
+   Total header size = 30 + filename_len + extra_len
+   ============================================================ *)
+
+implement zip_local_header_total_size(hdr) =
+  30 + hdr.filename_len + hdr.extra_len

--- a/zip.sats
+++ b/zip.sats
@@ -1,0 +1,88 @@
+(* zip.sats -- Type declarations for ZIP local file header parsing *)
+
+(* Uses dependent types and = "mac#" externs instead of C %{ blocks.
+   All byte-level access goes through declared primitives. *)
+
+#include "share/atspre_staload.hats"
+staload "./better_rust.sats"
+
+(* ============================================================
+   Byte access primitives (declared here, implemented in C)
+   ============================================================ *)
+
+(* Read a single unsigned byte from a raw buffer at offset *)
+fun buf_get_u8
+  {l:agz}{n,off:nat | off < n}
+  (pf: !raw_own(l, n), p: ptr l, off: int off)
+  : [v:nat | v < 256] int v = "mac#"
+
+(* Read a little-endian 16-bit unsigned integer *)
+fun buf_get_u16le
+  {l:agz}{n,off:nat | off + 1 < n}
+  (pf: !raw_own(l, n), p: ptr l, off: int off)
+  : [v:nat | v < 65536] int v = "mac#"
+
+(* Read a little-endian 32-bit unsigned integer *)
+fun buf_get_u32le
+  {l:agz}{n,off:nat | off + 3 < n}
+  (pf: !raw_own(l, n), p: ptr l, off: int off)
+  : int = "mac#"
+
+(* ============================================================
+   ZIP local file header layout (§4.3.7 of APPNOTE.TXT)
+
+   Offset  Size  Field
+   0       4     signature (0x04034b50)
+   4       2     version needed
+   6       2     general purpose bit flag
+   8       2     compression method
+   10      2     last mod file time
+   12      2     last mod file date
+   14      4     crc-32
+   18      4     compressed size
+   22      4     uncompressed size
+   26      2     file name length
+   28      2     extra field length
+   30      ...   file name
+   30+n    ...   extra field
+   ============================================================ *)
+
+(* Proof that a buffer contains a valid ZIP local file header signature *)
+dataprop ZIP_SIG_VALID(valid: bool) =
+  | ZIP_SIG_YES(true)
+  | ZIP_SIG_NO(false)
+
+(* Minimum size of a local file header (fixed fields only) *)
+stadef ZIP_LOCAL_HEADER_MIN = 30
+
+(* Check if a buffer starts with the ZIP local file header signature *)
+fun zip_check_signature
+  {l:agz}{n:nat | n >= 4}
+  (pf: !raw_own(l, n), p: ptr l)
+  : [b:bool] ZIP_SIG_VALID(b)
+
+(* Parsed ZIP local file header — all fields extracted *)
+typedef zip_local_header = @{
+  version_needed= int,
+  flags= int,
+  compression= int,
+  mod_time= int,
+  mod_date= int,
+  crc32= int,
+  compressed_size= int,
+  uncompressed_size= int,
+  filename_len= int,
+  extra_len= int
+}
+
+(* Parse a local file header from a buffer that has a valid signature.
+   Requires at least ZIP_LOCAL_HEADER_MIN bytes. *)
+fun zip_parse_local_header
+  {l:agz}{n:nat | n >= ZIP_LOCAL_HEADER_MIN}
+  (pf: !raw_own(l, n), p: ptr l)
+  : zip_local_header
+
+(* Total size of the local file header including variable-length fields *)
+fun zip_local_header_total_size
+  (hdr: &zip_local_header)
+  : int


### PR DESCRIPTION
ZIP local file header parsing using = "mac#" externs and dependent types instead of inline C %{ blocks. Byte access primitives are declared as extern functions, and all implementations are pure ATS2 with compile-time bounds checking via raw_own size indices.

https://claude.ai/code/session_01631NCRxryjWwTadxXMkEYD