### PR TITLE
Add ward_file_get_name_len and ward_file_get_name to file API

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -424,6 +424,8 @@ fun ward_on_clipboard_complete
 ```ats
 fun ward_file_open (input_node_id: int): ward_promise_pending(int)
 fun ward_file_get_size (): int
+fun ward_file_get_name_len (): int
+fun ward_file_get_name {n:pos} (len: int n): [l:agz] ward_arr(byte, l, n)
 fun ward_file_read {l:agz}{n:pos}
   (handle: int, file_offset: int, out: !ward_arr(byte, l, n), len: int n): int
 fun ward_file_close (handle: int): void

--- a/lib/file.dats
+++ b/lib/file.dats
@@ -39,6 +39,13 @@ implement
 ward_file_get_size() = _ward_bridge_stash_get_int(0)
 
 implement
+ward_file_get_name_len() = _ward_bridge_stash_get_int(2)
+
+implement
+ward_file_get_name{n}(len) =
+  ward_bridge_recv(_ward_bridge_stash_get_int(1), len)
+
+implement
 ward_file_read{l}{n}(handle, file_offset, out, len) = let
   val outp = $UNSAFE.castvwtp1{ptr}(out) (* [U-bw] *)
 in _ward_js_file_read(handle, file_offset, len, outp) end

--- a/lib/file.sats
+++ b/lib/file.sats
@@ -10,6 +10,12 @@ fun ward_file_open
 
 fun ward_file_get_size(): int
 
+(* Filename of last opened file. Length is 0 if no file. *)
+fun ward_file_get_name_len(): int
+fun ward_file_get_name
+  {n:pos}
+  (len: int n): [l:agz] ward_arr(byte, l, n)
+
 (* Synchronous read from cached ArrayBuffer. Returns bytes_read. *)
 fun ward_file_read
   {l:agz}{n:pos}

--- a/lib/ward_bridge.mjs
+++ b/lib/ward_bridge.mjs
@@ -482,6 +482,7 @@ export async function loadWard(wasmBytes, root, opts) {
   function wardJsFileOpen(inputNodeId, resolverId) {
     const el = nodes.get(inputNodeId);
     if (!el || !el.files || !el.files[0]) {
+      instance.exports.ward_bridge_stash_set_int(2, 0);
       instance.exports.ward_on_file_open(resolverId, 0, 0);
       return;
     }
@@ -491,9 +492,14 @@ export async function loadWard(wasmBytes, root, opts) {
       const handle = nextFileHandle++;
       const data = new Uint8Array(reader.result);
       fileCache.set(handle, data);
+      const nameBytes = new TextEncoder().encode(file.name);
+      const nameStashId = stashData(nameBytes);
+      instance.exports.ward_bridge_stash_set_int(1, nameStashId);
+      instance.exports.ward_bridge_stash_set_int(2, nameBytes.length);
       instance.exports.ward_on_file_open(resolverId, handle, data.length);
     };
     reader.onerror = () => {
+      instance.exports.ward_bridge_stash_set_int(2, 0);
       instance.exports.ward_on_file_open(resolverId, 0, 0);
     };
     reader.readAsArrayBuffer(file);


### PR DESCRIPTION
The JS bridge has file.name available but never passed it through. Now wardJsFileOpen stashes the filename as UTF-8 bytes via the existing data stash mechanism, and two new ATS functions retrieve it — same pattern as ward_fetch_get_body. Zero new $UNSAFE.