### PR TITLE
Fix contextmenu event missing target_node_id

### DIFF
--- a/lib/ward_bridge.mjs
+++ b/lib/ward_bridge.mjs
@@ -332,7 +332,7 @@ export async function loadWard(wasmBytes, root, opts) {
   // Encode event payload as binary (little-endian).
   // Returns Uint8Array or null for no payload.
   function encodeEventPayload(event, eventType) {
-    if (eventType === 'click' || eventType === 'pointerdown' ||
+    if (eventType === 'click' || eventType === 'contextmenu' || eventType === 'pointerdown' ||
         eventType === 'pointerup' || eventType === 'pointermove') {
       // [f64:clientX] [f64:clientY] [i32:target_node_id]
       const buf = new ArrayBuffer(20);


### PR DESCRIPTION
One-line fix: add contextmenu to MouseEvent payload encoding condition in encodeEventPayload