### PR TITLE
Add blob URL creation and revocation API

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -175,6 +175,7 @@ Used for attribute values and MIME types. `SAFE_CHAR` is a subset of `SAFE_CONTE
 - `nav.sats` / `nav.dats` -- URL navigation bridge
 - `window.sats` / `window.dats` -- window focus, visibility, logging
 - `dom_read.sats` / `dom_read.dats` -- DOM measurement and query
+- `blob.sats` / `blob.dats` -- blob URL creation and revocation
 - `ward_bridge.mjs` -- JS bridge: binary diff protocol, event listeners, data stash, HTML parsing
 - `runtime.h` -- freestanding WASM runtime: ATS2 macro infrastructure + ward type definitions
 - `runtime.c` -- free-list allocator (size classes: 32/128/512/4096/8192/16384/65536/262144/1048576 + oversized), arena allocator for WASM

--- a/Makefile
+++ b/Makefile
@@ -160,6 +160,10 @@ build/decompress_dats.c: lib/decompress.dats lib/decompress.sats $(BRIDGE_SATS) 
 build/notify_dats.c: lib/notify.dats lib/notify.sats $(BRIDGE_SATS) | build
 	$(PATSOPT) -o $@ -d $<
 
+# ATS2 -> C for blob module
+build/blob_dats.c: lib/blob.dats lib/blob.sats lib/memory.sats lib/memory.dats | build
+	$(PATSOPT) -o $@ -d $<
+
 # All bridge .sats/.dats for dom_exerciser deps
 BRIDGE_ALL_SATS := lib/memory.sats lib/memory.dats lib/dom.sats lib/dom.dats \
   lib/promise.sats lib/promise.dats lib/event.sats lib/event.dats \
@@ -169,7 +173,7 @@ BRIDGE_ALL_SATS := lib/memory.sats lib/memory.dats lib/dom.sats lib/dom.dats \
   lib/fetch.sats lib/fetch.dats \
   lib/clipboard.sats lib/clipboard.dats lib/file.sats lib/file.dats \
   lib/decompress.sats lib/decompress.dats lib/notify.sats lib/notify.dats \
-  lib/xml.sats lib/xml.dats
+  lib/xml.sats lib/xml.dats lib/blob.sats lib/blob.dats
 
 # ATS2 -> C for dom_exerciser
 build/dom_exerciser_dats.c: exerciser/dom_exerciser.dats $(BRIDGE_ALL_SATS) | build
@@ -218,6 +222,9 @@ build/decompress_dats.o: build/decompress_dats.c lib/runtime.h | build
 build/notify_dats.o: build/notify_dats.c lib/runtime.h | build
 	$(CLANG) $(WASM_NODE_CFLAGS) -c -o $@ $<
 
+build/blob_dats.o: build/blob_dats.c lib/runtime.h | build
+	$(CLANG) $(WASM_NODE_CFLAGS) -c -o $@ $<
+
 build/dom_exerciser_dats.o: build/dom_exerciser_dats.c lib/runtime.h | build
 	$(CLANG) $(WASM_NODE_CFLAGS) -c -o $@ $<
 
@@ -236,7 +243,7 @@ NODE_WASM_OBJS := build/memory_node_dats.o build/dom_node_dats.o build/promise_n
   build/event_dats.o build/idb_dats.o \
   build/window_dats.o build/nav_dats.o build/dom_read_dats.o build/listener_dats.o build/callback_dats.o \
   build/fetch_dats.o build/clipboard_dats.o build/file_dats.o build/decompress_dats.o build/xml_dats.o \
-  build/notify_dats.o \
+  build/notify_dats.o build/blob_dats.o \
   build/dom_exerciser_dats.o build/runtime_node.o
 
 # WASM exports for bridge callbacks

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -512,3 +512,25 @@ fun ward_on_permission_result
 fun ward_on_push_subscribe
   (resolver_id: int, json_len: int): void = "ext#ward_on_push_subscribe"
 ```
+
+---
+
+## blob -- Blob URL creation and revocation
+
+**Source:** `lib/blob.sats`
+
+### Functions
+
+```ats
+fun ward_create_blob_url {lb:agz}{n:pos}{m:pos}
+  (data: !ward_arr_borrow(byte, lb, n), data_len: int n,
+   mime: ward_safe_text(m), mime_len: int m): int   (* URL byte length, 0=failure *)
+
+fun ward_create_blob_url_get {n:pos}
+  (len: int n): [l:agz] ward_arr(byte, l, n)        (* retrieve stashed URL *)
+
+fun ward_revoke_blob_url {lb:agz}{n:pos}
+  (url: !ward_arr_borrow(byte, lb, n), url_len: int n): void
+```
+
+`ward_create_blob_url` creates a blob URL from binary data (via borrow) and a MIME type (safe text). The URL string is stashed for retrieval via `ward_create_blob_url_get`. Call `ward_revoke_blob_url` to release the blob URL when no longer needed.

--- a/docs/bridge.md
+++ b/docs/bridge.md
@@ -154,6 +154,13 @@ The bridge provides these functions as WASM imports under the `env` namespace:
 | `ward_js_push_subscribe` | `(vapidPtr, vapidLen, resolverId) -> void` | Subscribe to push |
 | `ward_js_push_get_subscription` | `(resolverId) -> void` | Get existing subscription |
 
+### Blob URL
+
+| Import | Signature | Purpose |
+|--------|-----------|---------|
+| `ward_js_create_blob_url` | `(dataPtr, dataLen, mimePtr, mimeLen) -> i32` | Create blob URL, stash URL string, return byte length |
+| `ward_js_revoke_blob_url` | `(urlPtr, urlLen) -> void` | Revoke a blob URL |
+
 ### Data stash
 
 | Import | Signature | Purpose |

--- a/lib/blob.dats
+++ b/lib/blob.dats
@@ -1,0 +1,54 @@
+(* blob.dats — Blob URL creation and revocation implementation *)
+
+#include "share/atspre_staload.hats"
+staload "./memory.sats"
+staload "./blob.sats"
+staload _ = "./memory.dats"
+
+extern fun _ward_js_create_blob_url
+  {m:pos}
+  (data: ptr, data_len: int, mime: ward_safe_text(m), mime_len: int m)
+  : int = "mac#ward_js_create_blob_url"
+
+extern fun _ward_js_revoke_blob_url
+  (url: ptr, url_len: int): void = "mac#ward_js_revoke_blob_url"
+
+extern fun _ward_bridge_stash_get_int
+  (slot: int): int = "mac#ward_bridge_stash_get_int"
+
+(*
+ * $UNSAFE justifications:
+ *
+ * [B1] castvwtp1{ptr}(data) in ward_create_blob_url:
+ *   Extracts raw pointer from ward_arr_borrow(byte) to pass to
+ *   ward_js_create_blob_url bridge import. This crosses the WASM/JS
+ *   boundary — the host API requires raw memory addresses.
+ *   Alternative considered: castfn cannot convert abstract viewtypes
+ *   to ptr. No prelude function extracts ptr from ward_arr_borrow.
+ *   User safety: data is !T (not consumed), length is dependent-typed.
+ *   No sequence of public API calls can trigger unsoundness.
+ *
+ * [B2] castvwtp1{ptr}(url) in ward_revoke_blob_url:
+ *   Same WASM/JS boundary crossing as [B1]. Extracts raw pointer
+ *   from borrow to pass URL bytes to the bridge for revocation.
+ *   Alternative considered: same as [B1].
+ *   User safety: url is !T (not consumed), length is dependent-typed.
+ *)
+
+implement
+ward_create_blob_url{lb}{n}{m}(data, data_len, mime, mime_len) = let
+  val dp = $UNSAFE.castvwtp1{ptr}(data) (* [B1] *)
+in
+  _ward_js_create_blob_url(dp, data_len, mime, mime_len)
+end
+
+implement
+ward_create_blob_url_get{n}(len) =
+  ward_bridge_recv(_ward_bridge_stash_get_int(1), len)
+
+implement
+ward_revoke_blob_url{lb}{n}(url, url_len) = let
+  val up = $UNSAFE.castvwtp1{ptr}(url) (* [B2] *)
+in
+  _ward_js_revoke_blob_url(up, url_len)
+end

--- a/lib/blob.sats
+++ b/lib/blob.sats
@@ -1,0 +1,21 @@
+(* blob.sats — Blob URL creation and revocation *)
+
+staload "./memory.sats"
+
+(* Create a blob URL from binary data and MIME type.
+   Returns URL byte length (0 on failure).
+   Stashes URL bytes for retrieval via ward_create_blob_url_get. *)
+fun ward_create_blob_url
+  {lb:agz}{n:pos}{m:pos}
+  (data: !ward_arr_borrow(byte, lb, n), data_len: int n,
+   mime: ward_safe_text(m), mime_len: int m): int
+
+(* Retrieve stashed blob URL. Call after ward_create_blob_url. *)
+fun ward_create_blob_url_get
+  {n:pos}
+  (len: int n): [l:agz] ward_arr(byte, l, n)
+
+(* Revoke a previously created blob URL. *)
+fun ward_revoke_blob_url
+  {lb:agz}{n:pos}
+  (url: !ward_arr_borrow(byte, lb, n), url_len: int n): void

--- a/lib/runtime.h
+++ b/lib/runtime.h
@@ -420,6 +420,10 @@ extern void ward_js_push_get_subscription(int resolver_id);
 /* HTML parsing JS import */
 extern int ward_js_parse_html(void *html, int html_len);
 
+/* Blob URL JS imports */
+extern int ward_js_create_blob_url(void *data, int data_len, void *mime, int mime_len);
+extern void ward_js_revoke_blob_url(void *url, int url_len);
+
 /* Callback registry — WASM export, JS calls this to fire callbacks */
 void ward_on_callback(int id, int payload);
 

--- a/lib/ward_bridge.mjs
+++ b/lib/ward_bridge.mjs
@@ -908,6 +908,28 @@ export async function loadWard(wasmBytes, root, opts) {
     return totalLen;
   }
 
+  // --- Blob URL ---
+
+  function wardJsCreateBlobUrl(dataPtr, dataLen, mimePtr, mimeLen) {
+    try {
+      const mime = readString(mimePtr, mimeLen);
+      const bytes = readBytes(dataPtr, dataLen);
+      const blob = new Blob([bytes], { type: mime });
+      const url = URL.createObjectURL(blob);
+      const urlBytes = new TextEncoder().encode(url);
+      const stashId = stashData(urlBytes);
+      instance.exports.ward_bridge_stash_set_int(1, stashId);
+      return urlBytes.length;
+    } catch(e) { return 0; }
+  }
+
+  function wardJsRevokeBlobUrl(urlPtr, urlLen) {
+    try {
+      const url = readString(urlPtr, urlLen);
+      URL.revokeObjectURL(url);
+    } catch(e) {}
+  }
+
   const imports = {
     env: {
       ...extraImports,
@@ -962,6 +984,9 @@ export async function loadWard(wasmBytes, root, opts) {
       ward_js_push_get_subscription: wardJsPushGetSubscription,
       // HTML parsing
       ward_js_parse_html: wardJsParseHtml,
+      // Blob URL
+      ward_js_create_blob_url: wardJsCreateBlobUrl,
+      ward_js_revoke_blob_url: wardJsRevokeBlobUrl,
       // Data stash
       ward_js_stash_read: wardJsStashRead,
     },

--- a/tests/bridge_dom_read.test.mjs
+++ b/tests/bridge_dom_read.test.mjs
@@ -57,3 +57,11 @@ describe('DOM read selection APIs', () => {
     // Bridge loads with ward_js_get_selection_range registered.
   });
 });
+
+describe('Blob URL APIs', () => {
+  it('bridge loads with blob URL imports registered', async () => {
+    // Verifies ward_js_create_blob_url and ward_js_revoke_blob_url
+    // are registered as WASM imports without errors.
+    await createWardInstance();
+  });
+});


### PR DESCRIPTION
## Summary
- Add new `blob` module (`lib/blob.sats`, `lib/blob.dats`) with 3 functions: `ward_create_blob_url`, `ward_create_blob_url_get`, `ward_revoke_blob_url`
- Add JS bridge functions for synchronous blob URL creation from binary data + MIME type, and revocation
- Implements Option C from #28 — generic blob URL primitive that lets the app handle CSS rewriting

## Test plan
- [x] `make check` passes (WASM build + exerciser + 17 anti-exerciser cases)
- [ ] Bridge loads with new blob URL imports in jsdom

Closes #28

🤖 Generated with [Claude Code](https://claude.com/claude-code)