### PR TITLE
Change blob URL MIME param to ward_safe_content_text

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -522,9 +522,9 @@ fun ward_on_push_subscribe
 ### Functions
 
 ```ats
-fun ward_create_blob_url {lb:agz}{n:pos}{m:pos}
+fun ward_create_blob_url {lb:agz}{n:pos}{lm:agz}{m:pos}
   (data: !ward_arr_borrow(byte, lb, n), data_len: int n,
-   mime: ward_safe_text(m), mime_len: int m): int   (* URL byte length, 0=failure *)
+   mime: !ward_safe_content_text(lm, m), mime_len: int m): int   (* URL byte length, 0=failure *)
 
 fun ward_create_blob_url_get {n:pos}
   (len: int n): [l:agz] ward_arr(byte, l, n)        (* retrieve stashed URL *)
@@ -533,4 +533,4 @@ fun ward_revoke_blob_url {lb:agz}{n:pos}
   (url: !ward_arr_borrow(byte, lb, n), url_len: int n): void
 ```
 
-`ward_create_blob_url` creates a blob URL from binary data (via borrow) and a MIME type (safe text). The URL string is stashed for retrieval via `ward_create_blob_url_get`. Call `ward_revoke_blob_url` to release the blob URL when no longer needed.
+`ward_create_blob_url` creates a blob URL from binary data (via borrow) and a MIME type (content text, which allows `/` for MIME types like `font/woff2`). The URL string is stashed for retrieval via `ward_create_blob_url_get`. Call `ward_revoke_blob_url` to release the blob URL when no longer needed.

--- a/lib/blob.dats
+++ b/lib/blob.dats
@@ -6,8 +6,7 @@ staload "./blob.sats"
 staload _ = "./memory.dats"
 
 extern fun _ward_js_create_blob_url
-  {m:pos}
-  (data: ptr, data_len: int, mime: ward_safe_text(m), mime_len: int m)
+  (data: ptr, data_len: int, mime: ptr, mime_len: int)
   : int = "mac#ward_js_create_blob_url"
 
 extern fun _ward_js_revoke_blob_url
@@ -19,14 +18,18 @@ extern fun _ward_bridge_stash_get_int
 (*
  * $UNSAFE justifications:
  *
- * [B1] castvwtp1{ptr}(data) in ward_create_blob_url:
- *   Extracts raw pointer from ward_arr_borrow(byte) to pass to
- *   ward_js_create_blob_url bridge import. This crosses the WASM/JS
- *   boundary — the host API requires raw memory addresses.
+ * [B1] castvwtp1{ptr}(data), castvwtp1{ptr}(mime) in ward_create_blob_url:
+ *   Extracts raw pointers from ward_arr_borrow(byte) and
+ *   ward_safe_content_text to pass to ward_js_create_blob_url bridge
+ *   import. This crosses the WASM/JS boundary — the host API requires
+ *   raw memory addresses.
  *   Alternative considered: castfn cannot convert abstract viewtypes
- *   to ptr. No prelude function extracts ptr from ward_arr_borrow.
- *   User safety: data is !T (not consumed), length is dependent-typed.
- *   No sequence of public API calls can trigger unsoundness.
+ *   to ptr. No prelude function extracts ptr from ward_arr_borrow or
+ *   ward_safe_content_text.
+ *   User safety: both are !T (not consumed), lengths are
+ *   dependent-typed. MIME uses ward_safe_content_text (compile-time
+ *   character checked). No sequence of public API calls can trigger
+ *   unsoundness.
  *
  * [B2] castvwtp1{ptr}(url) in ward_revoke_blob_url:
  *   Same WASM/JS boundary crossing as [B1]. Extracts raw pointer
@@ -36,10 +39,11 @@ extern fun _ward_bridge_stash_get_int
  *)
 
 implement
-ward_create_blob_url{lb}{n}{m}(data, data_len, mime, mime_len) = let
+ward_create_blob_url{lb}{n}{lm}{m}(data, data_len, mime, mime_len) = let
   val dp = $UNSAFE.castvwtp1{ptr}(data) (* [B1] *)
+  val mp = $UNSAFE.castvwtp1{ptr}(mime) (* [B1] *)
 in
-  _ward_js_create_blob_url(dp, data_len, mime, mime_len)
+  _ward_js_create_blob_url(dp, data_len, mp, mime_len)
 end
 
 implement

--- a/lib/blob.sats
+++ b/lib/blob.sats
@@ -6,9 +6,9 @@ staload "./memory.sats"
    Returns URL byte length (0 on failure).
    Stashes URL bytes for retrieval via ward_create_blob_url_get. *)
 fun ward_create_blob_url
-  {lb:agz}{n:pos}{m:pos}
+  {lb:agz}{n:pos}{lm:agz}{m:pos}
   (data: !ward_arr_borrow(byte, lb, n), data_len: int n,
-   mime: ward_safe_text(m), mime_len: int m): int
+   mime: !ward_safe_content_text(lm, m), mime_len: int m): int
 
 (* Retrieve stashed blob URL. Call after ward_create_blob_url. *)
 fun ward_create_blob_url_get


### PR DESCRIPTION
## Summary
- Change `ward_create_blob_url` MIME parameter from `ward_safe_text` to `!ward_safe_content_text` since MIME types contain `/` (e.g. `font/woff2`) which is not in `SAFE_CHAR`
- `SAFE_CONTENT_CHAR` allows printable ASCII including `/`, making it the correct type for MIME strings

## Test plan
- [x] `make check` passes (WASM build + exerciser + 17 anti-exerciser cases)

Closes #31

🤖 Generated with [Claude Code](https://claude.com/claude-code)